### PR TITLE
Update to NVim-TS-Context-Commentstring Integration

### DIFF
--- a/lua/config/comment.lua
+++ b/lua/config/comment.lua
@@ -3,25 +3,7 @@ local M = {}
 function M.setup()
   require("Comment").setup {
     ignore = "^$",
-    pre_hook = function(ctx)
-      local U = require "Comment.utils"
-
-      -- Determine whether to use linewise or blockwise commentstring
-      local type = ctx.ctype == U.ctype.line and "__default" or "__multiline"
-
-      -- Determine the location where to calculate commentstring from
-      local location = nil
-      if ctx.ctype == U.ctype.block then
-        location = require("ts_context_commentstring.utils").get_cursor_location()
-      elseif ctx.cmotion == U.cmotion.v or ctx.cmotion == U.cmotion.V then
-        location = require("ts_context_commentstring.utils").get_visual_start_location()
-      end
-
-      return require("ts_context_commentstring.internal").calculate_commentstring {
-        key = type,
-        location = location,
-      }
-    end,
+    pre_hook = require("ts_context_commentstring.integrations.comment_nvim").create_pre_hook(),
   }
 end
 


### PR DESCRIPTION
Update to NVim-TS-Context-Commentstring Integration [`37a97a0`](https://github.com/JoosepAlviste/nvim-ts-context-commentstring/commit/37a97a04c39f26fffe7745815517e1ce1a0eb3be)